### PR TITLE
fix MQTT RPC min_interval value convertion

### DIFF
--- a/dblogger.cpp
+++ b/dblogger.cpp
@@ -481,11 +481,12 @@ Json::Value TMQTTDBLoggerRpcHandler::GetValues(const Json::Value& params)
         }
     }
 
-    milliseconds minInterval(0);
-    JSON::Get(params, "min_interval", minInterval);
-    if (minInterval < milliseconds(0)) {
-        minInterval = milliseconds(0);
+    double minIntervalMs = 0;
+    JSON::Get(params, "min_interval", minIntervalMs);
+    if (minIntervalMs < 0) {
+        minIntervalMs = 0;
     }
+    auto minInterval = std::chrono::milliseconds(int64_t(minIntervalMs));
 
     std::vector<TChannelName> channels;
     for (const auto& channelItem : params["channels"]) {

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-db (2.5.1) stable; urgency=medium
+
+  * MQTT RPC min_interval entry parsing is fixed
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Fri, 17 Sep 2021 20:07:25 +0300
+
 wb-mqtt-db (2.5.0) stable; urgency=medium
 
   * Update dependency on libwbmqtt1 to support fixed libmosquitto facade

--- a/test/TRpcTest.get_records_v1_min_interval.dat
+++ b/test/TRpcTest.get_records_v1_min_interval.dat
@@ -1,0 +1,34 @@
+Register RPC history get_values
+Register RPC history get_channels
+RPC call get_values
+Arguments
+{"channels":[["wb-adc","Vin"],["wb-adc","A1"]],"ver":1,"timestamp":{"lt":954566430}, "min_interval": 95040.00000000001}
+Storage GetRecords
+  wb-adc/Vin
+  wb-adc/A1
+  1970-01-01 00:00:00 - 2000-04-01 05:20:30
+  from -1
+  maxRecords 2147483647
+  minInterval 95040 ms
+Response
+{
+  "values" : 
+  [
+    {
+      "c" : 1,
+      "i" : 1,
+      "retain" : false,
+      "t" : 954584430,
+      "v" : "test1"
+    },
+    {
+      "c" : 1,
+      "i" : 2,
+      "max" : "30",
+      "min" : "20",
+      "retain" : true,
+      "t" : 954584430,
+      "v" : "10"
+    }
+  ]
+}

--- a/test/rpc.test.cpp
+++ b/test/rpc.test.cpp
@@ -209,6 +209,16 @@ TEST_F(TRpcTest, get_records_v1)
     rpc.CallRpc("get_values", "{\"channels\":[[\"wb-adc\",\"Vin\"],[\"wb-adc\",\"A1\"]],\"ver\":1,\"timestamp\":{\"lt\":954566430}}");
 }
 
+TEST_F(TRpcTest, get_records_v1_min_interval)
+{
+    TLoggerCache cache(LoadConfig(testRootDir + "/wb-mqtt-db.conf", schemaFile).Cache);
+    TFakeMqttRpcServer rpc(*this);
+    TFakeStorage storage(*this);
+    TMQTTDBLoggerRpcHandler handler(cache, storage, std::chrono::seconds(5));
+    handler.Register(rpc);
+    rpc.CallRpc("get_values", "{\"channels\":[[\"wb-adc\",\"Vin\"],[\"wb-adc\",\"A1\"]],\"ver\":1,\"timestamp\":{\"lt\":954566430}, \"min_interval\": 95040.00000000001}");
+}
+
 TEST_F(TRpcTest, round)
 {
     TFakeStorage storage(*this);


### PR DESCRIPTION
After moving JSON std::chrono parsers to libwbmqtt1, RPC requests from homeui became broken because their min_interval value is Number not int (e.g. 95040.00000000001).

Fixed by explicitly treating this value as double.