### PR TITLE
Debug log channels enabling is fixed

### DIFF
--- a/dblogger.cpp
+++ b/dblogger.cpp
@@ -1,6 +1,7 @@
 #include "dblogger.h"
 
 #include "benchmark.h"
+#include "log.h"
 
 #include <wblib/json_utils.h>
 #include <wblib/wbmqtt.h>

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-db (2.5.5) stable; urgency=medium
+
+  * Debug log channels enabling is fixed
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.ru>  Tue, 07 Jun 2022 13:17:24 +0500
+
 wb-mqtt-db (2.5.4) stable; urgency=medium
 
   * Do not restart service with invalid config


### PR DESCRIPTION
Локальный Debug не был объявлен, потому ошибочно брался WBMQTT::Debug.