### PR TITLE
Port for Debian bullseye

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-buildDebSbuild defaultTargets: 'wb6'
+buildDebSbuild defaultTargets: 'bullseye-armhf'

--- a/Makefile
+++ b/Makefile
@@ -15,11 +15,8 @@ CXXFLAGS=-Wall -std=c++14 -I. -I./thirdparty/SQLiteCpp/include -Wno-psabi
 
 # We build armhf targets with an old version of sqlite
 CC_TARGET := $(shell $(CC) -dumpmachine)
-ifeq ($(CC_TARGET),arm-linux-gnueabihf)
-	CXXFLAGS+=-DSQLITE_USE_LEGACY_STRUCT
-endif
 
-LDFLAGS=-lwbmqtt1 -lsqlite3
+LDFLAGS=-lwbmqtt1 -lsqlite3 -lpthread
 
 ifeq ($(DEBUG), 1)
 	CXXFLAGS+=-O0 -g

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-db (2.8.0) stable; urgency=medium
+
+  * Port for Debian bullseye
+
+ -- Roman Kochkin <roman.kochkin@wirenboard.ru>  Mon, 10 Oct 2022 16:30:35 +0400
+
 wb-mqtt-db (2.7.0) stable; urgency=medium
 
   * Remove python dependency by removing old confconvert script


### PR DESCRIPTION
Пофиксил ошибки компиляции для bullseye: для новой версии sqlite в bullseye отпала необходимость во флаге SQLITE_USE_LEGACY_STRUCT.