### PR TITLE
Fix build

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-db (2.8.1) stable; urgency=medium
+
+  * Fix build
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Mon, 17 Oct 2022 07:25:25 -0400
+
 wb-mqtt-db (2.8.0) stable; urgency=medium
 
   * Port for Debian bullseye

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,6 @@
 wb-mqtt-db (2.8.2) stable; urgency=medium
 
-  * Fix build
+  * Fix build error (SQLite::Statement::bind does not support unsigned 64-bit integer value)
 
  -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Mon, 17 Oct 2022 07:25:25 -0400
 

--- a/sqlite_storage.cpp
+++ b/sqlite_storage.cpp
@@ -534,7 +534,7 @@ void TSqliteStorage::GetRecordsWithLimit
     if (!withAverage.empty()) {
         param_num = BindParams(query, param_num, withAverage, startTime, endTime, startId);
         auto minInterval = std::chrono::duration_cast<std::chrono::milliseconds>(endTime - startTime) / overallRecordsLimit;
-        query.bind(++param_num, minInterval.count());
+        query.bind(++param_num, static_cast<int64_t>(minInterval.count()));
     }
     query.bind(++param_num, maxRecords);
 


### PR DESCRIPTION
Build failed:
```
sqlite_storage.cpp: In member function 'virtual void TSqliteStorage::GetRecordsWithLimit(IRecordsVisitor&, const std::vector<TChannelName>&, std::chrono::_V2::system_clock::time_point, std::chrono::_V2::system_clock::time_point, int64_t, uint32_t, size_t)':
sqlite_storage.cpp:537:19: error: call of overloaded 'bind(int&, std::chrono::duration<long unsigned int, std::ratio<1, 1000> >::rep)' is ambiguous
  537 |         query.bind(++param_num, minInterval.count());
      |         ~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
[SQLite::Statement::bind](https://github.com/SRombauts/SQLiteCpp/blob/master/include/SQLiteCpp/Statement.h) does not support unsigned 64-bit integer value.