### PR TITLE
Return empty table if no channels found

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-db (2.8.3) stable; urgency=medium
+
+  * Return empty table if no rpc request channels match with available channels
+
+ -- Ekaterina Volkova <ekaterina.volkova@wirenboard.ru>  Mon, 28 Nov 2022 12:37:24 +0300
+
 wb-mqtt-db (2.8.2) stable; urgency=medium
 
   * Fix build error (SQLite::Statement::bind does not support unsigned 64-bit integer value)

--- a/sqlite_storage.cpp
+++ b/sqlite_storage.cpp
@@ -96,14 +96,14 @@ namespace
 
     void AddCommonWhereClause(string& queryStr, size_t channelsCount)
     {
+        queryStr += "channel IN ( ";
         if (channelsCount > 0) {
-            queryStr += "channel IN ( ";
-            for (size_t i = 0 ; i < channelsCount - 1; ++i) {
+            for (size_t i = 0; i < channelsCount - 1; ++i) {
                 queryStr += "?,";
             }
-            queryStr += "?) AND ";
+            queryStr += "?";
         }
-        queryStr += "timestamp > ? AND timestamp < ?";
+        queryStr += ") AND timestamp > ? AND timestamp < ?";
     }
 
     void AddWithAverageQuery(string& queryStr, size_t channelsCount)

--- a/storage.cpp
+++ b/storage.cpp
@@ -78,5 +78,5 @@ PChannelInfo IStorage::FindChannel(const TChannelName& channelName) const
     if (it != Channels.end()) {
         return it->second;
     }
-    return PChannelInfo();
+    return nullptr;
 }


### PR DESCRIPTION
Написала, чтобы возвращался пустой указатель, если не нашлось подходящих каналов. Исправила составление части запроса WHERE channel. Раньше, если массив с каналами был пуст, условие выборки каналов вообще не включалось. Сейчас выборка делается по пустому диапазону.