### PR TITLE
Fix missing channels request error

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-db (2.8.6) stable; urgency=medium
+
+  * Fix missing channels request error
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Fri, 09 Dec 2022 17:26:22 +0500
+
 wb-mqtt-db (2.8.5) stable; urgency=medium
 
   * Add make lcov target to generate test coverage, no functional changes

--- a/src/sqlite_storage.cpp
+++ b/src/sqlite_storage.cpp
@@ -446,6 +446,11 @@ void TSqliteStorage::GetRecordsWithLimit
         }
         AddWithAverageQuery(queryStr, withAverage.size());
     }
+
+    if (queryStr.empty()) {
+        // No channels to select
+        return;
+    }
     queryStr += " ORDER BY uid ASC LIMIT ?";
 
     std::lock_guard<std::mutex> lg(Mutex);

--- a/test/TSqliteStorageTest.get_unavailable_channel.dat
+++ b/test/TSqliteStorageTest.get_unavailable_channel.dat
@@ -1,0 +1,2 @@
+## With limit
+## With averaging interval

--- a/test/sqlite_storage.test.cpp
+++ b/test/sqlite_storage.test.cpp
@@ -338,3 +338,36 @@ TEST_F(TSqliteStorageTest, get_averaged_by_max_records)
          100,
          4);
 }
+
+TEST_F(TSqliteStorageTest, get_unavailable_channel)
+{
+    auto storage = std::make_unique<TSqliteStorage>(":memory:");
+    auto channel = storage->CreateChannel( {"test", "test3"});
+    storage->WriteChannel(*channel, "1", "", "", true, std::chrono::system_clock::time_point() + std::chrono::seconds(5));
+    storage->WriteChannel(*channel, "12", "10", "12", false, std::chrono::system_clock::time_point() + std::chrono::seconds(10));
+    storage->WriteChannel(*channel, "20.5", "10", "30", false, std::chrono::system_clock::time_point() + std::chrono::seconds(20));
+    storage->WriteChannel(*channel, "30.5", "20", "40", false, std::chrono::system_clock::time_point() + std::chrono::seconds(30));
+    storage->WriteChannel(*channel, "-165.777554", "1", "100", false, std::chrono::system_clock::time_point() + std::chrono::seconds(40));
+
+    TRecordsVisitor visitor(*this);
+
+    Emit() << "## With limit";
+    storage->GetRecordsWithLimit
+        (visitor, 
+         {{"test", "test2"}},
+         std::chrono::system_clock::time_point(),
+         std::chrono::system_clock::time_point() + std::chrono::seconds(100),
+         0,
+         100,
+         0);
+
+    Emit() << "## With averaging interval";
+    storage->GetRecordsWithAveragingInterval
+        (visitor, 
+         {{"test", "test2"}},
+         std::chrono::system_clock::time_point(),
+         std::chrono::system_clock::time_point() + std::chrono::seconds(100),
+         0,
+         100,
+         std::chrono::seconds(0));
+}


### PR DESCRIPTION
Добавил тест для https://github.com/wirenboard/wb-mqtt-db/pull/36
Исправил пойманный тестом баг, когда от запроса формировался лишь кусок `ORDER BY`.