### PR TITLE
Fix clang-tidy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ test/wb-homa-test
 *.tar.gz
 *.debhelper.log
 *.debhelper
+*.buildinfo
 */debian/*.substvars
 build
 compile_commands.json

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-db (2.8.12) stable; urgency=medium
+
+  * Fix clang-tidy, no functional changes
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Tue, 30 Jan 2024 10:30:00 +0400
+
 wb-mqtt-db (2.8.11) stable; urgency=medium
 
   * Fix clang-tidy issues

--- a/src/dblogger.cpp
+++ b/src/dblogger.cpp
@@ -4,7 +4,7 @@
 #include "log.h"
 
 #include <algorithm>
-#include <math.h>
+#include <cmath>
 #include <wblib/json_utils.h>
 #include <wblib/wbmqtt.h>
 


### PR DESCRIPTION
```sh
$ wbdev compiledb ./clang-tidy-subdirs.sh src test
...
/home/sikmir/wbdev/go/src/github.com/contactless/wb-mqtt-db/src/dblogger.cpp:64:37: error: no member named 'round' in namespace 'std'; did you mean simply 'round'? [clang-diagnostic-error]
        double v = round_to > 0.0 ? std::round(val / round_to) * round_to : val;
                                    ^~~~~~~~~~
                                    round
/usr/include/x86_64-linux-gnu/bits/mathcalls.h:298:14: note: 'round' declared here
__MATHCALLX (round,, (_Mdouble_ __x), (__const__));
             ^
```