### PR TITLE
Make data limit messages info-level instead of warning

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-db (2.8.13) stable; urgency=medium
+
+  * Make data limit messages info-level instead of warning
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Thu, 01 Feb 2024 13:41:50 +0600
+
 wb-mqtt-db (2.8.12) stable; urgency=medium
 
   * Fix clang-tidy, no functional changes

--- a/src/dblogger.cpp
+++ b/src/dblogger.cpp
@@ -737,7 +737,7 @@ void TMqttDbLoggerMessageHandler::CheckChannelOverflow(const TLoggingGroup& grou
 {
     if (group.MaxChannelRecords > 0) {
         if (channel.GetRecordCount() > group.MaxChannelRecords * (1 + RECORDS_CLEAR_THRESHOLDR)) {
-            LOG(Warn) << "Channel data limit is reached: channel " << channel.GetName() << ", row count "
+            LOG(Info) << "Channel data limit is reached: channel " << channel.GetName() << ", row count "
                       << channel.GetRecordCount() << ", limit " << group.MaxChannelRecords;
             Storage.DeleteRecords(channel, channel.GetRecordCount() - group.MaxChannelRecords);
         }
@@ -749,7 +749,7 @@ void TMqttDbLoggerMessageHandler::CheckGroupOverflow(const TLoggingGroup& group)
     if (group.MaxRecords > 0) {
         auto groupRecordCount = GetRecordCount(group);
         if (groupRecordCount > group.MaxRecords * (1 + RECORDS_CLEAR_THRESHOLDR)) {
-            LOG(Warn) << "Group data limit is reached: group " << group.Name << ", row count " << groupRecordCount
+            LOG(Info) << "Group data limit is reached: group " << group.Name << ", row count " << groupRecordCount
                       << ", limit " << group.MaxRecords;
             Storage.DeleteRecords(GetChannelInfos(group), groupRecordCount - group.MaxRecords);
         }


### PR DESCRIPTION
По многочисленным просьбам, чтобы логи не забивались жёлтыми записями о вполне нормальной ситуации