### PR TITLE
Fix several unchanged channels saving

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-db (2.8.14) stable; urgency=medium
+
+  * Fix several unchanged channels saving 
+
+ -- Ekaterina Volkova <ekaterina.volkova@wirenboard.com>  Tue, 09 Apr 2024 17:17:42 +0300
+
 wb-mqtt-db (2.8.13) stable; urgency=medium
 
   * Make data limit messages info-level instead of warning

--- a/src/dblogger.cpp
+++ b/src/dblogger.cpp
@@ -261,8 +261,7 @@ void TMQTTDBLogger::Start()
 
     RpcServer->Start();
     RpcHandler.Register(*RpcServer);
-
-    MessageHandler.Start(nextSaveTime);
+    bool start = true;
 
     while (Active) {
         steady_clock::time_point currentTime;
@@ -277,6 +276,10 @@ void TMQTTDBLogger::Start()
             }
             MessagesQueue.swap(localQueue);
             currentTime = steady_clock::now();
+            if (start) {
+                MessageHandler.Start(currentTime);
+                start = false;
+            }
         }
         nextSaveTime = MessageHandler.HandleMessages(localQueue, currentTime, system_clock::now());
     }

--- a/src/dblogger.cpp
+++ b/src/dblogger.cpp
@@ -645,6 +645,7 @@ steady_clock::time_point TMqttDbLoggerMessageHandler::Store(steady_clock::time_p
     for (auto& group: Cache.Groups) {
 
         bool saved = false;
+        bool usaved = false;
 
         for (auto& channel: group.Channels) {
             const char* saveStatus = "nothing to save";
@@ -655,7 +656,7 @@ steady_clock::time_point TMqttDbLoggerMessageHandler::Store(steady_clock::time_p
                 saved = true;
 
                 if (!channelData.Changed) {
-                    group.LastUSaved = currentTime;
+                    usaved = true;
                 }
                 WriteChannel(channelName, group, currentTime, writeTime, channelData);
             } else {
@@ -675,6 +676,10 @@ steady_clock::time_point TMqttDbLoggerMessageHandler::Store(steady_clock::time_p
 #ifndef NBENCHMARK
             benchmark.Enable();
 #endif
+        }
+
+        if (usaved) {
+            group.LastUSaved = currentTime;
         }
 
         if (currentTime >= group.LastUSaved + group.UnchangedInterval) {

--- a/test/TDBLoggerTest.several_unchanged.dat
+++ b/test/TDBLoggerTest.several_unchanged.dat
@@ -1,0 +1,90 @@
+Store by message 0
+Create channel wb-adc/Vin2
+Write "all" wb-adc/Vin2 0
+  Last value: 0.000
+  Changed: 1
+  Accumulator value count: 1
+Storage data:
+  Value: 0.000
+  Min: 
+  Max: 
+Set precision for wb-adc/Vin2 to 0.001
+Create channel wb-adc/Vin1
+Write "all" wb-adc/Vin1 0
+  Last value: 0.000
+  Changed: 1
+  Accumulator value count: 1
+Storage data:
+  Value: 0.000
+  Min: 
+  Max: 
+Set precision for wb-adc/Vin1 to 0.001
+Create channel wb-adc/Vin0
+Write "all" wb-adc/Vin0 0
+  Last value: 12.000
+  Changed: 1
+  Accumulator value count: 1
+Storage data:
+  Value: 12.000
+  Min: 
+  Max: 
+Set precision for wb-adc/Vin0 to 0.001
+Commit
+Store by message 1100
+Store by timeout 2000
+Write "all" wb-adc/Vin0 2000
+  Last value: 13.000
+  Changed: 1
+  Accumulator value count: 1
+Storage data:
+  Value: 13.000
+  Min: 
+  Max: 
+Commit
+Store by timeout 3000
+Write "all" wb-adc/Vin2 3000
+  Last value: 0.000
+  Changed: 0
+  Accumulator value count: 1
+Storage data:
+  Value: 0.000
+  Min: 
+  Max: 
+Write "all" wb-adc/Vin1 3000
+  Last value: 0.000
+  Changed: 0
+  Accumulator value count: 1
+Storage data:
+  Value: 0.000
+  Min: 
+  Max: 
+Commit
+Store by message 3100
+Store by timeout 4000
+Write "all" wb-adc/Vin0 4000
+  Last value: 14.000
+  Changed: 1
+  Accumulator value count: 1
+Storage data:
+  Value: 14.000
+  Min: 
+  Max: 
+Commit
+Store by timeout 6000
+Write "all" wb-adc/Vin2 6000
+  Last value: 0.000
+  Changed: 0
+  Accumulator value count: 1
+Storage data:
+  Value: 0.000
+  Min: 
+  Max: 
+Write "all" wb-adc/Vin1 6000
+  Last value: 0.000
+  Changed: 0
+  Accumulator value count: 1
+Storage data:
+  Value: 0.000
+  Min: 
+  Max: 
+Commit


### PR DESCRIPTION
Если в группе оказывалось несколько неизменившихся каналов, записывался только один из них так как обновлялось время LastUSaved и у всех остальных не срабатывал интервал.
Еще из за того что Start() хендлера вызывался со временем более ранним, чем первый проход обработчика, не срабатывало второе по порядку сохранение не меняющихся значений.