### PR TITLE
Add coverage report generation

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,5 @@
 buildDebSbuild defaultTargets: 'bullseye-armhf bullseye-arm64',
                defaultRunLintian: true,
-               defaultStyleCheckDirs: 'src test'
+               defaultStyleCheckDirs: 'src test',
+               defaultRunCoverage: false,
+               defaultCoverageMin: '75'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,4 +2,4 @@ buildDebSbuild defaultTargets: 'bullseye-armhf bullseye-arm64',
                defaultRunLintian: true,
                defaultStyleCheckDirs: 'src test',
                defaultRunCoverage: false,
-               defaultCoverageMin: '75'
+               defaultCoverageMin: '85'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,4 +2,4 @@ buildDebSbuild defaultTargets: 'bullseye-armhf bullseye-arm64',
                defaultRunLintian: true,
                defaultStyleCheckDirs: 'src test',
                defaultRunCoverage: false,
-               defaultCoverageMin: '85'
+               defaultCoverageMin: '80'

--- a/Makefile
+++ b/Makefile
@@ -46,8 +46,8 @@ export TEST_DIR_ABS = $(shell pwd)/$(TEST_DIR)
 
 VALGRIND_FLAGS = --error-exitcode=180 -q
 
-COV_REPORT ?= $(BUILD_DIR)/cov.html
-GCOVR_FLAGS := -e $(SQLITECPP_INCLUDE) -s --html $(COV_REPORT)
+COV_REPORT ?= $(BUILD_DIR)/cov
+GCOVR_FLAGS := -e $(SQLITECPP_INCLUDE) -s --html $(COV_REPORT).html -x $(COV_REPORT).xml
 ifneq ($(COV_FAIL_UNDER),)
 	GCOVR_FLAGS += --fail-under-line $(COV_FAIL_UNDER)
 endif

--- a/Makefile
+++ b/Makefile
@@ -94,4 +94,3 @@ install:
 
 	install -Dm0644 wb-mqtt-db.wbconfigs $(DESTDIR)/etc/wb-configs.d/16wb-mqtt-db
 	install -Dm0644 wb-mqtt-db.schema.json -t $(DESTDIR)$(PREFIX)/share/wb-mqtt-confed/schemas
-

--- a/Makefile
+++ b/Makefile
@@ -82,8 +82,7 @@ ifneq ($(DEBUG),)
 endif
 
 clean:
-	-rm -rf build/release
-	-rm -rf build/debug
+	-rm -rf build
 	-rm -f $(TEST_DIR)/*.dat.out
 	-rm -f $(TEST_DIR)/*.o $(TEST_DIR)/$(TEST_BIN)
 

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ export TEST_DIR_ABS = $(shell pwd)/$(TEST_DIR)
 VALGRIND_FLAGS = --error-exitcode=180 -q
 
 COV_REPORT ?= $(BUILD_DIR)/cov.html
-GCOVR_FLAGS := -e $(SQLITECPP_INCLUDE) --html $(COV_REPORT)
+GCOVR_FLAGS := -e $(SQLITECPP_INCLUDE) -s --html $(COV_REPORT)
 ifneq ($(COV_FAIL_UNDER),)
 	GCOVR_FLAGS += --fail-under-line $(COV_FAIL_UNDER)
 endif

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ export TEST_DIR_ABS = $(shell pwd)/$(TEST_DIR)
 VALGRIND_FLAGS = --error-exitcode=180 -q
 
 COV_REPORT ?= $(BUILD_DIR)/cov.html
-GCOVR_FLAGS := --html $(COV_REPORT)
+GCOVR_FLAGS := -e $(SQLITECPP_INCLUDE) --html $(COV_REPORT)
 ifneq ($(COV_FAIL_UNDER),)
 	GCOVR_FLAGS += --fail-under-line $(COV_FAIL_UNDER)
 endif

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-db (2.8.17) stable; urgency=medium
+
+  * Add coverage report generation, no functional changes
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Thu, 26 Sep 2024 20:10:00 +0400
+
 wb-mqtt-db (2.8.16) stable; urgency=medium
 
   * Add dependency from libwbmqtt1-5. No functional changes

--- a/debian/control
+++ b/debian/control
@@ -3,12 +3,13 @@ Maintainer: Wiren Board team <info@wirenboard.com>
 Section: misc
 Priority: optional
 Standards-Version: 3.9.2
-Build-Depends: debhelper (>= 10), 
-               pkg-config, 
-               libsqlite3-dev, 
+Build-Depends: debhelper (>= 10),
+               gcovr:all,
+               libgtest-dev,
+               libsqlite3-dev,
                libwbmqtt1-5-dev,
                libwbmqtt1-5-test-utils,
-               libgtest-dev
+               pkg-config
 Homepage: https://github.com/wirenboard/wb-mqtt-db
 
 Package: wb-mqtt-db

--- a/debian/rules
+++ b/debian/rules
@@ -1,5 +1,18 @@
 #!/usr/bin/make -f
 
+COV_FAIL_UNDER := $(patsubst cov-fail-under=%,%,$(filter cov-fail-under=%,$(DEB_BUILD_OPTIONS)))
+COV_REPORT     := $(patsubst cov-report=%,%,$(filter cov-report=%,$(DEB_BUILD_OPTIONS)))
+
+ifneq ($(COV_FAIL_UNDER),)
+	MAKEFLAGS += COV_FAIL_UNDER=$(COV_FAIL_UNDER)
+endif
+ifneq ($(COV_REPORT),)
+	MAKEFLAGS += COV_REPORT=$(COV_REPORT)
+endif
+ifneq (,$(findstring debug, $(DEB_BUILD_OPTIONS)))
+	MAKEFLAGS += DEBUG=1
+endif
+
 %:
 	dh $@ --parallel
 


### PR DESCRIPTION
How to use (with devcontainer):
```sh
make test DEBUG=1
open build/debug/cov.html
```
Using wbdev:
```sh
DEB_BUILD_OPTIONS="debug check cov-fail-under=85 cov-report=cov.html" ./wbdev cdeb
```

<img width="1680" alt="Näyttökuva 2024-9-30 kello 15 26 53" src="https://github.com/user-attachments/assets/260e7e7e-c348-4c21-b6d7-d02ee58968ab">
