### PR TITLE
Fix removing of overflowed records

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-db (2.9.1) stable; urgency=medium
+
+  * Fix removing of overflowed records from groups with wildcard patterns
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Mon, 17 Mar 2025 15:44:45 +0500
+
 wb-mqtt-db (2.9.0) stable; urgency=medium
 
   * Add buttons for moving groups in web interface

--- a/src/dblogger.cpp
+++ b/src/dblogger.cpp
@@ -32,7 +32,8 @@ namespace
         {
             for (auto& group: Cache.Groups) {
                 if (group.MatchPatterns(channel->GetName())) {
-                    group.Channels[channel->GetName()].ChannelInfo = channel;
+                    group.GetChannelData(channel->GetName()).ChannelInfo = channel;
+                    return;
                 }
             }
         }


### PR DESCRIPTION
Groups with wildcard patterns must not include channels from previous groups. At startup the service reads already stored channels from DB and then populates channels for each group. The groups are checked as they declared in config. If a matching group is found, the search is stopped. This way the order of groups in config is important. The first matching group is used.

В прошлой реализации проверялись всегда все группы и канал добавлялся во все подходящие группы. Канал всегда попадал в группу +/+, и старые записи чистились согласно настройкам этой группы.