### PR TITLE
Feature/6050 mqtt db desc

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-db (2.9.2) stable; urgency=medium
+
+  * Add group precedence note to schema
+
+ -- Anton Tarasov <anton.tarasov@wirenboard.com>  Mon, 27 Apr 2026 11:40:40 +0300
+
 wb-mqtt-db (2.9.1) stable; urgency=medium
 
   * Fix removing of overflowed records from groups with wildcard patterns

--- a/wb-mqtt-db.schema.json
+++ b/wb-mqtt-db.schema.json
@@ -25,6 +25,7 @@
         "groups": {
             "type": "array",
             "title": "Groups",
+            "description": "groups_description",
             "propertyOrder": 3,
 
             "items": {
@@ -177,6 +178,7 @@
         "en": {
             "wb-mqtt-db_description": "Settings of collecting and analizing historical data of MQTT channels",
             "request_timeout_description": "Maximum time to process data request (if no such data in RPC request)",
+            "groups_description": "If a channel is described in multiple groups, it will only be processed in the upper one.",
             "min_interval_description": "At most one value per specified time interval will be saved",
             "max_burst_description": "Additional records are made if parameter changes quickly. If maximum count reached additional recording stops until parameter stabilize"
         },
@@ -186,6 +188,7 @@
             "Enable debug logging": "Включить отладочные сообщения",
             "Default request timeout (s)": "Таймаут запроса данных (с)",
             "request_timeout_description": "Максимальное время для получения данных из истории (если не задано в RPC запросе)",
+            "groups_description": "Если канал описан в нескольких группах, он будет обработан только в верхней.",
             "Groups": "Группы",
             "Group": "Группа",
             "Group name": "Имя группы",


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Добавил описание для групп из задачи SOFT-6050

___________________________________
**Что поменялось для пользователей:**
Появилось описание для груп wb-mqtt-db: "Если канал описан в нескольких группах, он будет обработан только в верхней."

___________________________________
**Как проверял/а:**
На контроллере в homeui глазками убедился что надпись есть.

