### PR TITLE
fix: missing min/max columns for single-value records INT-1039

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-db (2.9.4) stable; urgency=medium
+
+  * Fix missing min/max columns for single-value records
+
+ -- Valerii Trovimov <valeriy.trofimov@wirenboard.com>  Tue, 14 May 2026 12:15:00 +0300
+
 wb-mqtt-db (2.9.3) stable; urgency=medium
 
   * Clarify wb-mqtt-db write period settings

--- a/src/dblogger.cpp
+++ b/src/dblogger.cpp
@@ -563,10 +563,18 @@ void TChannelWriter::WriteChannel(IStorage& storage,
     } else {
         // For single values set time to receive time not to write time
         writeTime = (channel.Changed ? channel.LastDataTime : writeTime);
+        // Preserve min/max as LastValue for numeric channels so downstream
+        // bucket aggregation (MIN(min)/MAX(max)) sees a real range across rows.
+        std::string minStr;
+        std::string maxStr;
+        if (channel.Accumulator.ValueCount > 0) {
+            minStr = channel.LastValue;
+            maxStr = channel.LastValue;
+        }
         storage.WriteChannel(*channel.ChannelInfo,
                              channel.LastValue,
-                             std::string(),
-                             std::string(),
+                             minStr,
+                             maxStr,
                              channel.Retained,
                              writeTime);
     }

--- a/src/dblogger.cpp
+++ b/src/dblogger.cpp
@@ -571,12 +571,7 @@ void TChannelWriter::WriteChannel(IStorage& storage,
             minStr = channel.LastValue;
             maxStr = channel.LastValue;
         }
-        storage.WriteChannel(*channel.ChannelInfo,
-                             channel.LastValue,
-                             minStr,
-                             maxStr,
-                             channel.Retained,
-                             writeTime);
+        storage.WriteChannel(*channel.ChannelInfo, channel.LastValue, minStr, maxStr, channel.Retained, writeTime);
     }
     storage.SetChannelPrecision(*channel.ChannelInfo, channel.Precision);
 }

--- a/test/TDBLoggerTest.burst.dat
+++ b/test/TDBLoggerTest.burst.dat
@@ -6,8 +6,8 @@ Write "all" wb-adc/Vin 0
   Accumulator value count: 1
 Storage data:
   Value: 12.000
-  Min: 
-  Max: 
+  Min: 12.000
+  Max: 12.000
 Set precision for wb-adc/Vin to 0.001
 Commit
 Store by message 1100
@@ -32,8 +32,8 @@ Write "all" wb-adc/Vin 14500
   Accumulator value count: 1
 Storage data:
   Value: 14.000
-  Min: 
-  Max: 
+  Min: 14.000
+  Max: 14.000
 Commit
 Store by timeout 15000
 Store by timeout 18000
@@ -44,16 +44,16 @@ Write "all" wb-adc/Vin 20500
   Accumulator value count: 1
 Storage data:
   Value: 11.000
-  Min: 
-  Max: 
+  Min: 11.000
+  Max: 11.000
 Write "all" wb-adc/Vin 20500
   Last value: 12.000
   Changed: 1
   Accumulator value count: 1
 Storage data:
   Value: 12.000
-  Min: 
-  Max: 
+  Min: 12.000
+  Max: 12.000
 Commit
 Store by timeout 21000
 Store by timeout 22500
@@ -74,8 +74,8 @@ Write "all" wb-adc/Vin 24500
   Accumulator value count: 1
 Storage data:
   Value: 11.000
-  Min: 
-  Max: 
+  Min: 11.000
+  Max: 11.000
 Commit
 Store by message 25000
 Store by message 25500

--- a/test/TDBLoggerTest.burstSwitch.dat
+++ b/test/TDBLoggerTest.burstSwitch.dat
@@ -6,8 +6,8 @@ Write "all" wb-adc/Vin 0
   Accumulator value count: 1
 Storage data:
   Value: 0
-  Min: 
-  Max: 
+  Min: 0
+  Max: 0
 Set precision for wb-adc/Vin to 1
 Write "all" wb-adc/Vin 0
   Last value: 1
@@ -15,16 +15,16 @@ Write "all" wb-adc/Vin 0
   Accumulator value count: 1
 Storage data:
   Value: 1
-  Min: 
-  Max: 
+  Min: 1
+  Max: 1
 Write "all" wb-adc/Vin 0
   Last value: 2
   Changed: 1
   Accumulator value count: 1
 Storage data:
   Value: 2
-  Min: 
-  Max: 
+  Min: 2
+  Max: 2
 Commit
 Store by timeout 2000
 Write "all" wb-adc/Vin 2000

--- a/test/TDBLoggerTest.burstSwitchAndValue.dat
+++ b/test/TDBLoggerTest.burstSwitchAndValue.dat
@@ -6,8 +6,8 @@ Write "all" wb-adc/Vin 0
   Accumulator value count: 1
 Storage data:
   Value: 1
-  Min: 
-  Max: 
+  Min: 1
+  Max: 1
 Set precision for wb-adc/Vin to 1
 Write "all" wb-adc/Vin 0
   Last value: 1
@@ -15,16 +15,16 @@ Write "all" wb-adc/Vin 0
   Accumulator value count: 1
 Storage data:
   Value: 1
-  Min: 
-  Max: 
+  Min: 1
+  Max: 1
 Write "all" wb-adc/Vin 0
   Last value: 1
   Changed: 0
   Accumulator value count: 1
 Storage data:
   Value: 1
-  Min: 
-  Max: 
+  Min: 1
+  Max: 1
 Create channel wb-adc/A1
 Write "all" wb-adc/A1 0
   Last value: 10.0
@@ -32,7 +32,7 @@ Write "all" wb-adc/A1 0
   Accumulator value count: 1
 Storage data:
   Value: 10.0
-  Min: 
-  Max: 
+  Min: 10.0
+  Max: 10.0
 Set precision for wb-adc/A1 to 0.1
 Commit

--- a/test/TDBLoggerTest.round.dat
+++ b/test/TDBLoggerTest.round.dat
@@ -10,8 +10,8 @@ Publish: /devices/wb-adc/controls/Vin/meta/precision: '0.1' (QoS 1, retained)
 Publish: /devices/wb-adc/controls/Vin: '12.000' (QoS 1, retained)
 Storage data:
   Value: 12.000
-  Min: 
-  Max: 
+  Min: 12.000
+  Max: 12.000
 Commit
 Publish: /devices/wb-adc/controls/Vin: '13.000' (QoS 1)
 Publish: /devices/wb-adc/controls/Vin: '14.000' (QoS 1)

--- a/test/TDBLoggerTest.save_precision.dat
+++ b/test/TDBLoggerTest.save_precision.dat
@@ -1,25 +1,25 @@
 Create channel wb-adc/Vin
 Storage data:
   Value: 12.000
-  Min: 
-  Max: 
+  Min: 12.000
+  Max: 12.000
 Set precision for wb-adc/Vin to 0.1
 Commit
 Storage data:
   Value: 12.001
-  Min: 
-  Max: 
+  Min: 12.001
+  Max: 12.001
 Commit
 Create channel wb-adc/A1
 Storage data:
   Value: 13
-  Min: 
-  Max: 
+  Min: 13
+  Max: 13
 Set precision for wb-adc/A1 to 1
 Commit
 Storage data:
   Value: 14.001
-  Min: 
-  Max: 
+  Min: 14.001
+  Max: 14.001
 Set precision for wb-adc/A1 to 0.001
 Commit

--- a/test/TDBLoggerTest.several_unchanged.dat
+++ b/test/TDBLoggerTest.several_unchanged.dat
@@ -6,8 +6,8 @@ Write "all" wb-adc/Vin2 0
   Accumulator value count: 1
 Storage data:
   Value: 0.000
-  Min: 
-  Max: 
+  Min: 0.000
+  Max: 0.000
 Set precision for wb-adc/Vin2 to 0.001
 Create channel wb-adc/Vin1
 Write "all" wb-adc/Vin1 0
@@ -16,8 +16,8 @@ Write "all" wb-adc/Vin1 0
   Accumulator value count: 1
 Storage data:
   Value: 0.000
-  Min: 
-  Max: 
+  Min: 0.000
+  Max: 0.000
 Set precision for wb-adc/Vin1 to 0.001
 Create channel wb-adc/Vin0
 Write "all" wb-adc/Vin0 0
@@ -26,8 +26,8 @@ Write "all" wb-adc/Vin0 0
   Accumulator value count: 1
 Storage data:
   Value: 12.000
-  Min: 
-  Max: 
+  Min: 12.000
+  Max: 12.000
 Set precision for wb-adc/Vin0 to 0.001
 Commit
 Store by message 1100
@@ -38,8 +38,8 @@ Write "all" wb-adc/Vin0 2000
   Accumulator value count: 1
 Storage data:
   Value: 13.000
-  Min: 
-  Max: 
+  Min: 13.000
+  Max: 13.000
 Commit
 Store by timeout 3000
 Write "all" wb-adc/Vin2 3000
@@ -48,16 +48,16 @@ Write "all" wb-adc/Vin2 3000
   Accumulator value count: 1
 Storage data:
   Value: 0.000
-  Min: 
-  Max: 
+  Min: 0.000
+  Max: 0.000
 Write "all" wb-adc/Vin1 3000
   Last value: 0.000
   Changed: 0
   Accumulator value count: 1
 Storage data:
   Value: 0.000
-  Min: 
-  Max: 
+  Min: 0.000
+  Max: 0.000
 Commit
 Store by message 3100
 Store by timeout 4000
@@ -67,8 +67,8 @@ Write "all" wb-adc/Vin0 4000
   Accumulator value count: 1
 Storage data:
   Value: 14.000
-  Min: 
-  Max: 
+  Min: 14.000
+  Max: 14.000
 Commit
 Store by timeout 6000
 Write "all" wb-adc/Vin2 6000
@@ -77,14 +77,14 @@ Write "all" wb-adc/Vin2 6000
   Accumulator value count: 1
 Storage data:
   Value: 0.000
-  Min: 
-  Max: 
+  Min: 0.000
+  Max: 0.000
 Write "all" wb-adc/Vin1 6000
   Last value: 0.000
   Changed: 0
   Accumulator value count: 1
 Storage data:
   Value: 0.000
-  Min: 
-  Max: 
+  Min: 0.000
+  Max: 0.000
 Commit

--- a/test/TDBLoggerTest.two_groups.dat
+++ b/test/TDBLoggerTest.two_groups.dat
@@ -6,8 +6,8 @@ Write "most specific" wb-adc/Vin 0
   Accumulator value count: 1
 Storage data:
   Value: 12.000
-  Min: 
-  Max: 
+  Min: 12.000
+  Max: 12.000
 Set precision for wb-adc/Vin to 0.001
 Commit
 Store by message 100
@@ -18,8 +18,8 @@ Write "most specific2" wb-adc/A1 100
   Accumulator value count: 1
 Storage data:
   Value: 2.000
-  Min: 
-  Max: 
+  Min: 2.000
+  Max: 2.000
 Set precision for wb-adc/A1 to 0.001
 Commit
 Store by message 1100
@@ -53,8 +53,8 @@ Write "most specific" wb-adc/Vin 6000
   Accumulator value count: 1
 Storage data:
   Value: 14.000
-  Min: 
-  Max: 
+  Min: 14.000
+  Max: 14.000
 Commit
 Store by timeout 8000
 Write "most specific2" wb-adc/A1 8000
@@ -63,8 +63,8 @@ Write "most specific2" wb-adc/A1 8000
   Accumulator value count: 1
 Storage data:
   Value: 4.000
-  Min: 
-  Max: 
+  Min: 4.000
+  Max: 4.000
 Commit
 Store by timeout 9000
 Store by timeout 12000

--- a/test/TDBLoggerTest.two_overlapping_groups.dat
+++ b/test/TDBLoggerTest.two_overlapping_groups.dat
@@ -6,8 +6,8 @@ Write "most specific" wb-adc/Vin 0
   Accumulator value count: 1
 Storage data:
   Value: 12.000
-  Min: 
-  Max: 
+  Min: 12.000
+  Max: 12.000
 Set precision for wb-adc/Vin to 0.001
 Commit
 Store by message 100
@@ -18,8 +18,8 @@ Write "general" wb-adc/A1 100
   Accumulator value count: 1
 Storage data:
   Value: 2.000
-  Min: 
-  Max: 
+  Min: 2.000
+  Max: 2.000
 Set precision for wb-adc/A1 to 0.001
 Commit
 Store by message 1100
@@ -53,8 +53,8 @@ Write "most specific" wb-adc/Vin 6000
   Accumulator value count: 1
 Storage data:
   Value: 14.000
-  Min: 
-  Max: 
+  Min: 14.000
+  Max: 14.000
 Commit
 Store by timeout 8000
 Write "general" wb-adc/A1 8000
@@ -63,8 +63,8 @@ Write "general" wb-adc/A1 8000
   Accumulator value count: 1
 Storage data:
   Value: 4.000
-  Min: 
-  Max: 
+  Min: 4.000
+  Max: 4.000
 Commit
 Store by timeout 9000
 Store by timeout 12000


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**

При просмотре истории каналов с быстрыми переключениями (например, `buzzer/frequency`, который меняется каждые 30 секунд) на больших окнах графика виден "выпрямленный" график по среднему значению вместо реальных колебаний канала. Пользователи воспринимают это как ошибку логирования: "канал постоянно включён" или "значение не меняется".

Корень: `wb-mqtt-db` копит min/max/avg в `TAccumulator` и пишет тройку `(value=avg, min, max)` раз в `min_interval`. Но если в окно `min_interval` попало ровно одно числовое значение (`ValueCount == 1`), пишется только `value=LastValue`, а поля `min` и `max` остаются пустыми строками.

На длинных окнах frontend запрашивает бакетную агрегацию (`AVG(value), MIN(min), MAX(max) GROUP BY ts_bucket`). Когда часть строк в бакете имеет пустые `min`/`max`, SQL-агрегация даёт некорректный результат — диапазон значений теряется, остаётся только среднее.

Граничный случай особенно заметен, когда период переключений канала близок к `min_interval` (например, переключения каждые 30 с при `min_interval=30 с`): в каждое окно попадает ровно 1 значение, и `min`/`max` никогда не пишутся.

Затрагивает всех пользователей, которые анализируют историю каналов с переключениями.

___________________________________
**Что поменялось для пользователей:**

- Для новых записей, попадающих в граничный случай "1 значение в окне", в БД теперь пишутся `min = max = LastValue` вместо пустых строк.
- На графиках истории при бакетной агрегации диапазон min/max теперь корректно собирается из всех записей бакета — даже если часть из них была "одиночными".
- Видимый эффект работает в паре с фиксом в `homeui` (рендер band'а для switch-каналов и корректное использование min/max для всех типов).
- Старые записи в БД не меняются — фикс работает только для новых данных, поступающих после установки обновления.

___________________________________
**Как проверял/а:**

Еще не проверял.
